### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/speed/security/code-scanning/1](https://github.com/sibiraj-s/speed/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and builds it, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
